### PR TITLE
Move @mapbox/geojsonhint into tests

### DIFF
--- a/lib/lint-gazetteer.js
+++ b/lib/lint-gazetteer.js
@@ -1,14 +1,5 @@
-const geojsonhint = require('@mapbox/geojsonhint');
-
 function lint(gazetteer) {
-  let errors = [];
-
-  const geojsonErrors = geojsonhint.hint(gazetteer);
-  if (geojsonErrors.length > 0) {
-    geojsonErrors.forEach(error => {
-      errors.push(error.message);
-    });
-  }
+  const errors = [];
 
   const gazetteerName = gazetteer.name;
   if (typeof gazetteerName !== 'string') {

--- a/test.js
+++ b/test.js
@@ -3,13 +3,29 @@ const path = require('path');
 const assert = require('assert');
 const gazetteers = fs.readdirSync(path.resolve(__dirname,'./mapbox-streets'));
 const lint = require('./lib/lint-gazetteer');
+const geojsonhint = require('@mapbox/geojsonhint');
 
 let gazetteerNames = [];
 
 gazetteers.forEach(gazetteer => {
   const filePath = path.resolve(__dirname,`./mapbox-streets/${gazetteer}`);
   const gazetteerData = JSON.parse(fs.readFileSync(filePath));
-  const errors = lint(gazetteerData);
+
+  const errors = [];
+
+  const geojsonErrors = geojsonhint.hint(gazetteerData);
+  if (geojsonErrors.length > 0) {
+    geojsonErrors.forEach(error => {
+      errors.push(error.message);
+    });
+  }
+
+  const gazetteerLintErrors = lint(gazetteerData);
+  if (gazetteerLintErrors.length > 0) {
+    gazetteerLintErrors.forEach(error => {
+      errors.push(error);
+    });
+  }
 
   // Lint all features.
   assert(


### PR DESCRIPTION
Drop this dependency from lint-gazetteer.js which now just has the responsibility of linting the spec. Closes #41.