### PR TITLE
Add a road network gazetteer

### DIFF
--- a/mapbox-streets/road-network-gazetteer.json
+++ b/mapbox-streets/road-network-gazetteer.json
@@ -523,7 +523,7 @@
       "properties": {
         "place_name": "Tokyo, Japan",
         "zoom": 12,
-        "description": "The large network of roads inx Tokyo.",
+        "description": "The large network of roads in Tokyo.",
         "highlights": [
           {
             "geometry_type": "MultiLineString",

--- a/mapbox-streets/road-network-gazetteer.json
+++ b/mapbox-streets/road-network-gazetteer.json
@@ -1,0 +1,595 @@
+{
+  "type": "FeatureCollection",
+  "name": "road-network-gazetteer",
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [-3.704, 40.395]
+      },
+      "properties": {
+        "place_name": "Madrid, Spain",
+        "zoom": 17,
+        "highlights": [
+          {
+            "geometry_type": "MultiLineString",
+            "data_layer": "road",
+            "data_layer_fields": {
+              "class": "motorway",
+              "structure": "tunnel"
+            }
+          },
+          {
+            "geometry_type": "MultiLineString",
+            "data_layer": "road",
+            "data_layer_fields": {
+              "class": "motorway-link",
+              "structure": "tunnel"
+            }
+          },
+          {
+            "geometry_type": "MultiLineString",
+            "data_layer": "road",
+            "data_layer_fields": {
+              "class": "trunk",
+              "oneway": "true"
+            }
+          },
+          {
+            "geometry_type": "MultiLineString",
+            "data_layer": "road",
+            "data_layer_fields": {
+              "class": "path"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [103.761, 1.404]
+      },
+      "properties": {
+        "place_name": "Singapore",
+        "zoom": 10,
+        "highlights": [
+          {
+            "geometry_type": "MultiLineString",
+            "data_layer": "road",
+            "data_layer_fields": {
+              "class": "motorway"
+            }
+          },
+          {
+            "geometry_type": "MultiLineString",
+            "data_layer": "road",
+            "data_layer_fields": {
+              "class": "trunk"
+            }
+          },
+          {
+            "geometry_type": "MultiLineString",
+            "data_layer": "road",
+            "data_layer_fields": {
+              "class": "primary"
+            }
+          },
+          {
+            "geometry_type": "MultiLineString",
+            "data_layer": "road",
+            "data_layer_fields": {
+              "class": "secondary"
+            }
+          },
+          {
+            "geometry_type": "MultiLineString",
+            "data_layer": "road",
+            "data_layer_fields": {
+              "class": "tertiary"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [-75.161, 39.917]
+      },
+      "properties": {
+        "place_name": "Philadelphia, Pennsylvania",
+        "zoom": 15,
+        "highlights": [
+          {
+            "geometry_type": "LineString",
+            "data_layer": "road",
+            "data_layer_fields": {
+              "class": "street",
+              "oneway": "true"
+            }
+          },
+          {
+            "geometry_type": "MultiLineString",
+            "data_layer": "road",
+            "data_layer_fields": {
+              "class": "service"
+            }
+          },
+          {
+            "geometry_type": "LineString",
+            "data_layer": "road",
+            "data_layer_fields": {
+              "class": "primary"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [-99.12, 19.458]
+      },
+      "properties": {
+        "place_name": "Mexico City, Mexico",
+        "zoom": 11,
+        "highlights": [
+          {
+            "geometry_type": "MultiLineString",
+            "data_layer": "road",
+            "data_layer_fields": {
+              "class": "motorway"
+            }
+          },
+          {
+            "geometry_type": "MultiLineString",
+            "data_layer": "road",
+            "data_layer_fields": {
+              "class": "trunk"
+            }
+          },
+          {
+            "geometry_type": "MultiLineString",
+            "data_layer": "road",
+            "data_layer_fields": {
+              "class": "primary"
+            }
+          },
+          {
+            "geometry_type": "MultiLineString",
+            "data_layer": "road",
+            "data_layer_fields": {
+              "class": "secondary"
+            }
+          },
+          {
+            "geometry_type": "MultiLineString",
+            "data_layer": "road",
+            "data_layer_fields": {
+              "class": "tertiary"
+            }
+          },
+          {
+            "geometry_type": "MultiLineString",
+            "data_layer": "road",
+            "data_layer_fields": {
+              "class": "treet"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [12.591, 55.672]
+      },
+      "properties": {
+        "place_name": "Copenhagen, Denmark",
+        "zoom": 13,
+        "highlights": [
+          {
+            "geometry_type": "LineString",
+            "data_layer": "road",
+            "data_layer_fields": {
+              "class": "tertiary",
+              "structure": "bridge"
+            }
+          },
+          {
+            "geometry_type": "MultiLineString",
+            "data_layer": "road",
+            "data_layer_fields": {
+              "class": "path"
+            }
+          },
+          {
+            "geometry_type": "LineString",
+            "data_layer": "road",
+            "data_layer_fields": {
+              "class": "street"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [-84.258, 33.891]
+      },
+      "properties": {
+        "place_name": "Atlanta, Georgia",
+        "zoom": 16,
+        "highlights": [
+          {
+            "geometry_type": "MultiLineString",
+            "data_layer": "road",
+            "data_layer_fields": {
+              "class": "motorway"
+            }
+          },
+          {
+            "geometry_type": "MultiLineString",
+            "data_layer": "road",
+            "data_layer_fields": {
+              "class": "motorway_link",
+              "structure": "bridge",
+              "oneway": "true"
+            }
+          },
+          {
+            "geometry_type": "MultiLineString",
+            "data_layer": "road",
+            "data_layer_fields": {
+              "class": "secondary"
+            }
+          },
+          {
+            "geometry_type": "LineString",
+            "data_layer": "road",
+            "data_layer_fields": {
+              "class": "tertiary"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [116.78, 39.533]
+      },
+      "properties": {
+        "place_name": "Northeastern China",
+        "zoom": 8,
+        "highlights": [
+          {
+            "geometry_type": "MultiLineString",
+            "data_layer": "road",
+            "data_layer_fields": {
+              "class": "motorway"
+            }
+          },
+          {
+            "geometry_type": "MultiLineString",
+            "data_layer": "road",
+            "data_layer_fields": {
+              "class": "trunk"
+            }
+          },
+          {
+            "geometry_type": "MultiLineString",
+            "data_layer": "road",
+            "data_layer_fields": {
+              "class": "primary"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [-122.397, 37.793]
+      },
+      "properties": {
+        "place_name": "San Francisco, California",
+        "zoom": 18,
+        "highlights": [
+          {
+            "geometry_type": "MultiPoint",
+            "data_layer": "road",
+            "data_layer_fields": {
+              "class": "level_crossing"
+            }
+          },
+          {
+            "geometry_type": "LineString",
+            "data_layer": "road",
+            "data_layer_fields": {
+              "class": "tertiary"
+            }
+          },
+          {
+            "geometry_type": "MultiLineString",
+            "data_layer": "road",
+            "data_layer_fields": {
+              "class": "service"
+            }
+          },
+          {
+            "geometry_type": "Polygon",
+            "data_layer": "road",
+            "data_layer_fields": {
+              "class": "pedestrian"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [79.086, 21.14]
+      },
+      "properties": {
+        "place_name": "Nagpur, India",
+        "zoom": 11,
+        "highlights": [
+          {
+            "geometry_type": "MultiLineString",
+            "data_layer": "road",
+            "data_layer_fields": {
+              "class": "trunk"
+            }
+          },
+          {
+            "geometry_type": "MultiLineString",
+            "data_layer": "road",
+            "data_layer_fields": {
+              "class": "primary"
+            }
+          },
+          {
+            "geometry_type": "MultiLineString",
+            "data_layer": "road",
+            "data_layer_fields": {
+              "class": "secondary"
+            }
+          },
+          {
+            "geometry_type": "MultiLineString",
+            "data_layer": "road",
+            "data_layer_fields": {
+              "class": "tertiary"
+            }
+          },
+          {
+            "geometry_type": "MultiLineString",
+            "data_layer": "road",
+            "data_layer_fields": {
+              "class": "street"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [-71.065, 42.355]
+      },
+      "properties": {
+        "place_name": "Boston, Massachusetts",
+        "zoom": 16,
+        "highlights": [
+          {
+            "geometry_type": "MultiLineString",
+            "data_layer": "road",
+            "data_layer_fields": {
+              "class": "path"
+            }
+          },
+          {
+            "geometry_type": "Polygon",
+            "data_layer": "road",
+            "data_layer_fields": {
+              "class": "pedestrian"
+            }
+          },
+          {
+            "geometry_type": "LineString",
+            "data_layer": "road",
+            "data_layer_fields": {
+              "class": "street"
+            }
+          },
+          {
+            "geometry_type": "LineString",
+            "data_layer": "road",
+            "data_layer_fields": {
+              "class": "service"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [-75.584, 40.138]
+      },
+      "properties": {
+        "place_name": "Northeaster United States",
+        "zoom": 6,
+        "highlights": [
+          {
+            "geometry_type": "MultiLineString",
+            "data_layer": "road",
+            "data_layer_fields": {
+              "class": "motorway"
+            }
+          },
+          {
+            "geometry_type": "MultiLineString",
+            "data_layer": "road",
+            "data_layer_fields": {
+              "class": "trunk"
+            }
+          },
+          {
+            "geometry_type": "MultiLineString",
+            "data_layer": "road",
+            "data_layer_fields": {
+              "class": "primary"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [-0.087, 51.508]
+      },
+      "properties": {
+        "place_name": "London, England",
+        "zoom": 15,
+        "highlights": [
+          {
+            "geometry_type": "MultiLineString",
+            "data_layer": "road",
+            "data_layer_fields": {
+              "class": "ferry"
+            }
+          },
+          {
+            "geometry_type": "MultiLineString",
+            "data_layer": "road",
+            "data_layer_fields": {
+              "class": "primary",
+              "oneway": "true"
+            }
+          },
+          {
+            "geometry_type": "LineString",
+            "data_layer": "road",
+            "data_layer_fields": {
+              "class": "street"
+            }
+          },
+          {
+            "geometry_type": "MultiLineString",
+            "data_layer": "road",
+            "data_layer_fields": {
+              "class": "major_rail"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [139.758, 35.675]
+      },
+      "properties": {
+        "place_name": "Tokyo, Japan",
+        "zoom": 12,
+        "highlights": [
+          {
+            "geometry_type": "MultiLineString",
+            "data_layer": "road",
+            "data_layer_fields": {
+              "class": "motorway"
+            }
+          },
+          {
+            "geometry_type": "MultiLineString",
+            "data_layer": "road",
+            "data_layer_fields": {
+              "class": "trunk"
+            }
+          },
+          {
+            "geometry_type": "MultiLineString",
+            "data_layer": "road",
+            "data_layer_fields": {
+              "class": "primary"
+            }
+          },
+          {
+            "geometry_type": "MultiLineString",
+            "data_layer": "road",
+            "data_layer_fields": {
+              "class": "secondary"
+            }
+          },
+          {
+            "geometry_type": "MultiLineString",
+            "data_layer": "road",
+            "data_layer_fields": {
+              "class": "tertiary"
+            }
+          },
+          {
+            "geometry_type": "MultiLineString",
+            "data_layer": "road",
+            "data_layer_fields": {
+              "class": "street"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [18.555, -33.912]
+      },
+      "properties": {
+        "place_name": "Cape Town, South Africa",
+        "zoom": 14,
+        "highlights": [
+          {
+            "geometry_type": "LineString",
+            "data_layer": "road",
+            "data_layer_fields": {
+              "class": "tertiary"
+            }
+          },
+          {
+            "geometry_type": "LineString",
+            "data_layer": "road",
+            "data_layer_fields": {
+              "class": "street"
+            }
+          },
+          {
+            "geometry_type": "MultiLineString",
+            "data_layer": "road",
+            "data_layer_fields": {
+              "class": "major_rail"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/mapbox-streets/road-network-gazetteer.json
+++ b/mapbox-streets/road-network-gazetteer.json
@@ -56,7 +56,7 @@
       "properties": {
         "place_name": "Singapore",
         "zoom": 10,
-        "description": "Expressway system of Singapore.",
+        "description": "Expressway system in Singapore.",
         "highlights": [
           {
             "geometry_type": "MultiLineString",
@@ -233,6 +233,7 @@
       "properties": {
         "place_name": "Atlanta, Georgia",
         "zoom": 16,
+        "description": "A multi-level stack interchange known as Spaghetti Junction.",
         "highlights": [
           {
             "geometry_type": "MultiLineString",
@@ -276,7 +277,7 @@
       "properties": {
         "place_name": "Northeastern China",
         "zoom": 8,
-        "description": "Ring roads Beijing and Tianjin",
+        "description": "Ring roads around Beijing and Tianjin.",
         "highlights": [
           {
             "geometry_type": "MultiLineString",
@@ -353,7 +354,7 @@
       "properties": {
         "place_name": "Nagpur, India",
         "zoom": 11,
-        "description": "Dense street network in Nagpur.",
+        "description": "The dense street network in Nagpur.",
         "highlights": [
           {
             "geometry_type": "MultiLineString",
@@ -479,7 +480,7 @@
       "properties": {
         "place_name": "London, England",
         "zoom": 15,
-        "description": "Ferry lines and bridges along the Thames River",
+        "description": "Ferry lines and bridges along the Thames River.",
         "highlights": [
           {
             "geometry_type": "MultiLineString",
@@ -522,7 +523,7 @@
       "properties": {
         "place_name": "Tokyo, Japan",
         "zoom": 12,
-        "description": "The large network of roads around Tokyo.",
+        "description": "The large network of roads inx Tokyo.",
         "highlights": [
           {
             "geometry_type": "MultiLineString",

--- a/mapbox-streets/road-network-gazetteer.json
+++ b/mapbox-streets/road-network-gazetteer.json
@@ -11,6 +11,7 @@
       "properties": {
         "place_name": "Madrid, Spain",
         "zoom": 17,
+        "description": "Tunnels along Madrid's M-30 motorway.",
         "highlights": [
           {
             "geometry_type": "MultiLineString",
@@ -55,6 +56,7 @@
       "properties": {
         "place_name": "Singapore",
         "zoom": 10,
+        "description": "Expressway system of Singapore.",
         "highlights": [
           {
             "geometry_type": "MultiLineString",
@@ -103,6 +105,7 @@
       "properties": {
         "place_name": "Philadelphia, Pennsylvania",
         "zoom": 15,
+        "description": "City grid of Philadelphia.",
         "highlights": [
           {
             "geometry_type": "LineString",
@@ -138,6 +141,7 @@
       "properties": {
         "place_name": "Mexico City, Mexico",
         "zoom": 11,
+        "description": "Motorways and arterial roads linking neighborhoods in Mexico City.",
         "highlights": [
           {
             "geometry_type": "MultiLineString",
@@ -193,6 +197,7 @@
       "properties": {
         "place_name": "Copenhagen, Denmark",
         "zoom": 13,
+        "description": "Bridges, ferry lines, and streets weaving through the inner harbor.",
         "highlights": [
           {
             "geometry_type": "LineString",
@@ -271,6 +276,7 @@
       "properties": {
         "place_name": "Northeastern China",
         "zoom": 8,
+        "description": "Ring roads Beijing and Tianjin",
         "highlights": [
           {
             "geometry_type": "MultiLineString",
@@ -305,6 +311,7 @@
       "properties": {
         "place_name": "San Francisco, California",
         "zoom": 18,
+        "description": "Rail and rail crossings intersecting with roads.",
         "highlights": [
           {
             "geometry_type": "MultiPoint",
@@ -346,6 +353,7 @@
       "properties": {
         "place_name": "Nagpur, India",
         "zoom": 11,
+        "description": "Dense street network in Nagpur.",
         "highlights": [
           {
             "geometry_type": "MultiLineString",
@@ -394,6 +402,7 @@
       "properties": {
         "place_name": "Boston, Massachusetts",
         "zoom": 16,
+        "description": "Pedestrian paths crossing through Boston Common.",
         "highlights": [
           {
             "geometry_type": "MultiLineString",
@@ -433,8 +442,9 @@
         "coordinates": [-75.584, 40.138]
       },
       "properties": {
-        "place_name": "Northeaster United States",
+        "place_name": "Northeastern United States",
         "zoom": 6,
+        "description": "Roads linking cities along the northeast coast.",
         "highlights": [
           {
             "geometry_type": "MultiLineString",
@@ -469,6 +479,7 @@
       "properties": {
         "place_name": "London, England",
         "zoom": 15,
+        "description": "Ferry lines and bridges along the Thames River",
         "highlights": [
           {
             "geometry_type": "MultiLineString",
@@ -511,6 +522,7 @@
       "properties": {
         "place_name": "Tokyo, Japan",
         "zoom": 12,
+        "description": "The large network of roads around Tokyo.",
         "highlights": [
           {
             "geometry_type": "MultiLineString",
@@ -566,6 +578,7 @@
       "properties": {
         "place_name": "Cape Town, South Africa",
         "zoom": 14,
+        "description": "Rail lines through the city grid.",
         "highlights": [
           {
             "geometry_type": "LineString",


### PR DESCRIPTION
Created a road network gazetteer! This includes 14 places from zoom levels 6-18. Below are the screenshots from cartocam.

@dasulit this is ready for review. Let me know if you have any feedback on the number of locations I have chosen/the range of places. 

Closes #44

<img width="1191" alt="Screen Shot 2019-07-02 at 9 35 47 PM" src="https://user-images.githubusercontent.com/14204192/60563610-679f2a80-9d11-11e9-9c7a-1cfc538d80fc.png">
<img width="1191" alt="Screen Shot 2019-07-02 at 9 35 30 PM" src="https://user-images.githubusercontent.com/14204192/60563611-679f2a80-9d11-11e9-8045-b6ff542ff234.png">
<img width="1191" alt="Screen Shot 2019-07-02 at 9 35 26 PM" src="https://user-images.githubusercontent.com/14204192/60563612-679f2a80-9d11-11e9-8527-1cce7fcbee07.png">
<img width="1191" alt="Screen Shot 2019-07-02 at 9 35 18 PM" src="https://user-images.githubusercontent.com/14204192/60563614-679f2a80-9d11-11e9-94da-27d95a1ee610.png">
<img width="1191" alt="Screen Shot 2019-07-02 at 9 35 12 PM" src="https://user-images.githubusercontent.com/14204192/60563615-679f2a80-9d11-11e9-9a30-2958d8e91092.png">
<img width="1191" alt="Screen Shot 2019-07-02 at 9 35 02 PM" src="https://user-images.githubusercontent.com/14204192/60563616-6837c100-9d11-11e9-9c49-4857bc8cbcfb.png">
<img width="1191" alt="Screen Shot 2019-07-02 at 9 34 55 PM" src="https://user-images.githubusercontent.com/14204192/60563617-6837c100-9d11-11e9-95e3-85f5f5aaef4d.png">

