### PR TITLE
Allow Multi* types

### DIFF
--- a/lib/lint-gazetteer.js
+++ b/lib/lint-gazetteer.js
@@ -61,8 +61,8 @@ function lint(gazetteer) {
             const geometryType = highlight.geometry_type;
             const dataLayer = highlight.data_layer;
 
-            if (geometryType && /^(?!Point$|LineString$|Polygon$).*/.test(geometryType)) {
-              errors.push(`${gazetteerName}, feature ${featureIndex}, highlight ${highlightIndex}: must be one of Point, LineString, or Polygon`);
+            if (geometryType && /^(?!Point$|LineString$|Polygon|MultiPoint|MultiLineString|MultiPolygon$).*/.test(geometryType)) {
+              errors.push(`${gazetteerName}, feature ${featureIndex}, highlight ${highlightIndex}: must be one of Point, LineString, Polygon, MultiPoint, MultiLineString, or MultiPolygon`);
             }
 
             if (typeof dataLayer !== 'string' || dataLayer.length > 30) {


### PR DESCRIPTION
Add support for Multi* types. I may be missing context on why these were initially excluded but I don't see why they should be 🤷‍♀ 

@ClareTrainor for review